### PR TITLE
Support for sign checks for Success / Fail callback redirects

### DIFF
--- a/Robokassa.php
+++ b/Robokassa.php
@@ -100,17 +100,17 @@ class Robokassa extends CApplicationComponent
         return false;
     }
 
-    private function checkResultSignature($OutSum, $InvId, $SignatureValue)
+    public function checkResultSignature($OutSum, $InvId, $SignatureValue, $checkType = 0)
     {
         $keys = array(
             $OutSum,
             $InvId,
-            $this->sMerchantPass2,
+            $checkType ? $this->sMerchantPass1 : $this->sMerchantPass2,
         );
 
         $sign = strtoupper(md5(implode(':', $keys)));
 
-        if ($SignatureValue == $sign)
+        if (strtoupper($SignatureValue) == $sign)
             return true;
 
         return false;


### PR DESCRIPTION
This pull request added support for signature checks for Success or Fail callback redirects. 3 main changes:
- **checkResultSignature** method is now public
- added new arg **checkType** to differentiate merchant passes
- both signs (POSTed and created) are now in *_uppercase_

Example of use:

``` php
...
    public function actionSuccess() {
        $rc = Yii::app()->robokassa;
        $InvId = Yii::app()->request->getParam('InvId');
        $OutSum = Yii::app()->request->getParam('OutSum');
        $SignatureValue = Yii::app()->request->getParam('SignatureValue');

        if($rc->checkResultSignature($OutSum, $InvId, $SignatureValue, 1)) { // note the last arg
            // redirect to very secure url... 
            ....
        }
    }
...
```
